### PR TITLE
feat: return file size in Download model

### DIFF
--- a/Classes/Domain/Model/Download.php
+++ b/Classes/Domain/Model/Download.php
@@ -84,4 +84,13 @@ class Download extends AbstractJsonSerializableEntity
 
         return $this;
     }
+
+    public function getFileSize(): int
+    {
+        $file = $this->getFile();
+        if ($file?->getOriginalResource() !== null) {
+            return $file->getOriginalResource()->getSize();
+        }
+        return 0;
+    }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -2,7 +2,7 @@ plugin {
     tx_downloads {
         settings {
             jsonFields {
-                Remind\Downloads\Domain\Model\Download = name,file,thumbnail
+                Remind\Downloads\Domain\Model\Download = name,file,thumbnail,fileSize
                 Remind\Downloads\Domain\Model\Group = name,description,image,downloads
             }
             displayNameFields = name


### PR DESCRIPTION
**Summary**
This pull request adds a new method, `getFileSize()`, to the `Remind\Downloads\Domain\Model\Download class`.

**Details**
New method:
`getFileSize(): int`
Returns the file size (in bytes) of the associated file, or 0 if no file is set.

**Implementation:**
The method checks if a file is attached and if its original resource is available. If so, it returns the file size using TYPO3's FAL API. Otherwise, it returns 0.

**Motivation**
This addition allows consumers of the Download model to easily retrieve the file size for display or processing purposes, improving the model's usability and encapsulation.